### PR TITLE
Add client w/ TLS verification off for extending provider options

### DIFF
--- a/cleanhttp.go
+++ b/cleanhttp.go
@@ -1,6 +1,7 @@
 package cleanhttp
 
 import (
+	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
@@ -33,6 +34,23 @@ func DefaultPooledTransport() *http.Transport {
 	return transport
 }
 
+// Test not for prod use
+func NoTLSVerifyTransport() *http.Transport {
+
+	transport := &http.Transport{
+	Proxy: http.ProxyFromEnvironment,
+	Dial: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).Dial,
+	TLSHandshakeTimeout: 10 * time.Second,
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	DisableKeepAlives:   true,
+	MaxIdleConnsPerHost: -1,
+	}
+	return transport
+}
+
 // DefaultClient returns a new http.Client with similar default values to
 // http.Client, but with a non-shared Transport, idle connections disabled, and
 // keepalives disabled.
@@ -49,5 +67,12 @@ func DefaultClient() *http.Client {
 func DefaultPooledClient() *http.Client {
 	return &http.Client{
 		Transport: DefaultPooledTransport(),
+	}
+}
+
+// Test not for prod use
+func NoTLSVerifyClient() *http.Client {
+	return &http.Client{
+		Transport: NoTLSVerifyTransport(),
 	}
 }

--- a/cleanhttp.go
+++ b/cleanhttp.go
@@ -34,7 +34,9 @@ func DefaultPooledTransport() *http.Transport {
 	return transport
 }
 
-// Test not for prod use
+// NoTLSVerifyTransport returns a new http.Transport with options identical to
+// DefaultTransport however with TLS verification turned off. Intended only for
+// use with internal resources that are not routed on the public Internet.
 func NoTLSVerifyTransport() *http.Transport {
 
 	transport := &http.Transport{
@@ -70,7 +72,9 @@ func DefaultPooledClient() *http.Client {
 	}
 }
 
-// Test not for prod use
+// NoTLSVerifyClient returns a new http.Client with options identical to
+// DefaultClient however with TLS verification turned off. Intended only for
+// use with internal resources that are not available on the public Internet.
 func NoTLSVerifyClient() *http.Client {
 	return &http.Client{
 		Transport: NoTLSVerifyTransport(),


### PR DESCRIPTION
In the course of modifying a provider I needed to add this extra client to cleanhttp to work around golang + macosx not searching for private certificates.  In my provider I default the use of this client to 'off' as I would recommend everyone do, and not allow environmental variables to determine it's use either.

Please let me know if there is anything I can do to help get this change merged.  I will be filing my associated PR for the terraform provider (powerdns) shortly.  Thank you!