### PR TITLE
enable DualStack in the Transport Dialer

### DIFF
--- a/cleanhttp.go
+++ b/cleanhttp.go
@@ -26,6 +26,7 @@ func DefaultPooledTransport() *http.Transport {
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
+			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
Enable DualStack in the dialer to fasttrack around broken ipv6
configurations.

The default now for the http package is also to use DualStack, so this
should be safe in all cases.