### PR TITLE
Add pkg.go.dev documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cleanhttp
+# cleanhttp [![Go Reference](https://pkg.go.dev/badge/github.com/hashicorp/go-cleanhttp.svg)](https://pkg.go.dev/github.com/hashicorp/go-cleanhttp)
 
 Functions for accessing "clean" Go http.Client values
 


### PR DESCRIPTION
Just a minor convenience for users looking for the documentation/methods of the library as they are not actually mentioned in the README.