### PR TITLE
fix: drop deprecated net.Dialer.DualStack setting

### DIFF
--- a/cleanhttp.go
+++ b/cleanhttp.go
@@ -29,7 +29,6 @@ func DefaultPooledTransport() *http.Transport {
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
## Summary
`net.Dialer.DualStack` has been deprecated since Go 1.20 and has no effect (Fast Fallback / dual-stack is always enabled). This module requires Go 1.24, so the field is pure noise in `DefaultPooledTransport`.

## Test plan
- [x] `go test ./...`