### PR TITLE
fix: raise default MaxIdleConnsPerHost floor for pooled transports

### DIFF
--- a/cleanhttp.go
+++ b/cleanhttp.go
@@ -36,9 +36,21 @@ func DefaultPooledTransport() *http.Transport {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		ForceAttemptHTTP2:     true,
-		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+		MaxIdleConnsPerHost:   defaultMaxIdleConnsPerHost(),
 	}
 	return transport
+}
+
+// defaultMaxIdleConnsPerHost returns a floor for idle connections per host.
+// Network I/O is not strictly CPU-bound, so GOMAXPROCS alone underestimates
+// useful concurrency on small core counts (see #15).
+func defaultMaxIdleConnsPerHost() int {
+	n := runtime.GOMAXPROCS(0) * 2
+	const minIdle = 8
+	if n < minIdle {
+		return minIdle
+	}
+	return n
 }
 
 // DefaultClient returns a new http.Client with similar default values to

--- a/idle_conns_test.go
+++ b/idle_conns_test.go
@@ -1,0 +1,22 @@
+package cleanhttp
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestDefaultMaxIdleConnsPerHostFloor(t *testing.T) {
+	got := defaultMaxIdleConnsPerHost()
+	if got < 8 {
+		t.Fatalf("got %d, want >= 8", got)
+	}
+	// When GOMAXPROCS is high, scale with 2x procs.
+	n := runtime.GOMAXPROCS(0) * 2
+	if n > 8 && got != n {
+		t.Fatalf("got %d want %d", got, n)
+	}
+	tr := DefaultPooledTransport()
+	if tr.MaxIdleConnsPerHost != got {
+		t.Fatalf("transport=%d helper=%d", tr.MaxIdleConnsPerHost, got)
+	}
+}


### PR DESCRIPTION
## What

`DefaultPooledTransport` sets `MaxIdleConnsPerHost` to `max(GOMAXPROCS*2, 8)`.

## Why

On 1–2 core machines, `GOMAXPROCS+1` underestimates useful idle connections for network-bound clients. See #15.

## Test

- `TestDefaultMaxIdleConnsPerHostFloor`